### PR TITLE
Change Polyfill Provider

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -15,7 +15,7 @@ useHead({
   link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
   script: [
     {
-      src: 'https://polyfill.io/v3/polyfill.min.js?features=default%2Ces2015%2Ces6%2Ces5',
+      src: 'https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=default%2Ces2015%2Ces6%2Ces5',
       crossorigin: 'anonymous',
     },
   ],

--- a/public/event_sources.json
+++ b/public/event_sources.json
@@ -571,6 +571,11 @@
 			"name": "Greater Brewing Company",
 			"googleCalendarId": "c_aiork42cpqlb1t487q65gslmqk@group.calendar.google.com",
 			"city": "Santa Cruz"
+		},
+		{
+			"name": "San Francisco Queer Pinball League",
+			"googleCalendarId": "0bead8563c1c04721df993607fdb8afb93ccbb6f4eb56f7ffd3c73f54dc94f66@group.calendar.google.com",
+			"city": "San Francisco"
 		}
 	],
 	"wordPressTribe": [


### PR DESCRIPTION
Hey, just wanted to bring to your attention @bytewife that polyfill.io has been deprecated and an identical provider hosted by Cloudflare just dropped. [Here's the article](https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet) from Cloudlare that contains more details. If you try and use bay.lgbt at this point on an older browser you'll probably get issues since polyfill.io seems to just simply be down at this point as far as I can tell.