### PR TITLE
Change Mother from Instagram to Squarespace source

### DIFF
--- a/public/event_sources.json
+++ b/public/event_sources.json
@@ -147,14 +147,6 @@
 			"city": "San Francisco"
 		},
 		{
-			"name": "Mother",
-			"username": "motherbarsf",
-			"context_clues": [
-				""
-			],
-			"city": "San Francisco"
-		},
-		{
 			"name": "non-binary run club",
 			"username": "nbrcsf",
 			"context_clues": [
@@ -607,6 +599,11 @@
 			"name": "Guildhouse",
 			"url": "https://www.guildhouse.gg/events?format=json",
 			"city": "San Jose"
+		},
+		{
+			"name": "Mother",
+			"url": "https://www.mothersf.com/events-1?format=json",
+			"city": "San Francisco"
 		},
 		{
 			"name": "The Neighbor's Pub",


### PR DESCRIPTION
It appears that Instagram event sourcing is currently broken, and Mother in SF has a machine-readable events feed via their Squarespace site's JSON feed. This commit removes the Mother Instagram source and adds a Mother Squarespace source.